### PR TITLE
Fix storage account name length

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1,6 +1,12 @@
 param prefix string = 'RegInsightDemo'
 param location string = 'eastus'
 
+// Storage account names must be 24 characters or less. We combine a shortened
+// prefix, the string 'sa', and a unique string derived from the resource group
+// ID. uniqueString() returns a 13-character value, so the prefix portion must
+// be no more than 9 characters to stay within the limit.
+var saPrefix = toLower(substring(prefix, 0, 9))
+
 /* 
   The resource group must be created at the subscription scope.
   Remove this resource and create the resource group before deploying this Bicep file,
@@ -30,8 +36,10 @@ resource openai 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
 }
 
 resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
-  // Storage account names must be between 3 and 24 characters, lowercase, and unique
-  name: toLower('${prefix}sa${uniqueString(resourceGroup().id)}')
+  // Compose the storage account name from the shortened prefix, 'sa', and a
+  // deterministic unique string. This ensures the name meets the length and
+  // character requirements while remaining unique within Azure.
+  name: '${saPrefix}sa${uniqueString(resourceGroup().id)}'
   location: location
   sku: {
     name: 'Standard_LRS'


### PR DESCRIPTION
## Summary
- ensure storage account name stays under 24 chars

## Testing
- `pytest -q` *(fails: command not found)*
- `az bicep version` *(fails: command not found)*