### PR TITLE
Fix storage account name construction

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -6,6 +6,9 @@ param location string = 'eastus'
 // ID. uniqueString() returns a 13-character value, so the prefix portion must
 // be no more than 9 characters to stay within the limit.
 var saPrefix = toLower(substring(prefix, 0, 9))
+// Unique suffix derived from the resource group ensures the storage account
+// name remains globally unique while staying within the 24 character limit.
+var saSuffix = uniqueString(resourceGroup().id)
 
 /* 
   The resource group must be created at the subscription scope.
@@ -36,10 +39,10 @@ resource openai 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
 }
 
 resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
-  // Compose the storage account name from the shortened prefix, 'sa', and a
-  // deterministic unique string. This ensures the name meets the length and
-  // character requirements while remaining unique within Azure.
-  name: '${saPrefix}sa'
+  // Compose the storage account name from the shortened prefix, 'sa', and the
+  // deterministic unique suffix. This keeps the name under 24 characters and
+  // uses only lower-case letters and numbers.
+  name: '${saPrefix}sa${saSuffix}'
   location: location
   sku: {
     name: 'Standard_LRS'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.100"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
   }
 }
 
@@ -15,6 +19,16 @@ provider "azurerm" {
 
 variable "prefix" { type = string }
 variable "location" { type = string default = "eastus" }
+
+resource "random_string" "sa_suffix" {
+  length  = 13
+  upper   = false
+  special = false
+}
+
+locals {
+  sa_prefix = substr(lower(var.prefix), 0, 9)
+}
 
 resource "azurerm_resource_group" "rg" {
   name     = "${var.prefix}-rg"
@@ -39,7 +53,7 @@ resource "azurerm_cognitive_account" "openai" {
 }
 
 resource "azurerm_storage_account" "sa" {
-  name                     = "${var.prefix}sa"
+  name                     = "${local.sa_prefix}sa${random_string.sa_suffix.result}"
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = var.location
   account_tier             = "Standard"


### PR DESCRIPTION
## Summary
- append a unique suffix for storage account names in Bicep
- compute a compliant name for storage account in Terraform

## Testing
- `terraform init` *(fails: command not found)*